### PR TITLE
Change to shorter namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## 2.0.0 - 2020-04-17
+
+:boom: Breaking changes! New namespace. Run `composer dump-autoload` after update.
+
+### Changed
+
+- Change namespace to top level `Adevade`. Use `Adevade\Seconds::class` instead of `Adevade\Seconds\Seconds::class` in ^2.0.
+
 ## 1.1.0 - 2020-04-17
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ composer require adevade/seconds
 ## Usage
 
 ```php
-use Adevade\Seconds\Seconds;
+use Adevade\Seconds;
 
 Seconds::fromMinutes(2); // returns => (int) 120
 ```

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     },
     "autoload": {
         "psr-4": {
-            "Adevade\\Seconds\\": "src"
+            "Adevade\\": "src"
         }
     },
     "autoload-dev": {

--- a/src/Seconds.php
+++ b/src/Seconds.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Adevade\Seconds;
+namespace Adevade;
 
 use BadMethodCallException;
 use InvalidArgumentException;

--- a/tests/SecondsTest.php
+++ b/tests/SecondsTest.php
@@ -2,7 +2,7 @@
 
 namespace Adevade\Seconds\Tests;
 
-use Adevade\Seconds\Seconds;
+use Adevade\Seconds;
 use BadMethodCallException;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
@@ -80,7 +80,7 @@ class SecondsTest extends TestCase
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage(
-            'Adevade\Seconds\Seconds::fromMinutes(int $seconds) expects an integer.'
+            'Adevade\Seconds::fromMinutes(int $seconds) expects an integer.'
         );
 
         Seconds::fromMinutes();
@@ -91,7 +91,7 @@ class SecondsTest extends TestCase
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage(
-            'Adevade\Seconds\Seconds::fromDays(int $seconds) expects an integer.'
+            'Adevade\Seconds::fromDays(int $seconds) expects an integer.'
         );
 
         Seconds::fromDays('4');
@@ -102,7 +102,7 @@ class SecondsTest extends TestCase
     {
         $this->expectException(BadMethodCallException::class);
         $this->expectExceptionMessage(
-            'Adevade\Seconds\Seconds::invalidMethod() does not exist.'
+            'Adevade\Seconds::invalidMethod() does not exist.'
         );
 
         Seconds::invalidMethod(12);


### PR DESCRIPTION
This PR changes the old namespace `Adevade\Seconds\Seconds::class` to use a shorter `Adevade\Seconds::class`. If you update from ^1.0 make sure you update the namespace everywhere and run `composer dump-autoload` after update.