### PR TITLE
Drop php7 support #5

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-version: ["7.4", "8.0", "8.1"]
+        php-version: ["8.0", "8.1"]
 
     steps:
       - name: Checkout

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "php": "^8"
     },
     "require-dev": {
-        "phpunit/phpunit": "^8"
+        "phpunit/phpunit": "^9"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -18,10 +18,10 @@
         }
     ],
     "require": {
-        "php": "^7.4|^8.0"
+        "php": "^8"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.0"
+        "phpunit/phpunit": "^8"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Dropped support for php7, and added support for 8.x instead.
I also changed the phpunit version to 8.x, for consistency.